### PR TITLE
Send lines directly eliminating the temp file

### DIFF
--- a/ftplugin/python_cmdline.vim
+++ b/ftplugin/python_cmdline.vim
@@ -1,5 +1,5 @@
 function! PythonSourceLines(lines)
-    call VimCmdLineSendCmd(join(add(a:lines, ''), "\n"))
+    call VimCmdLineSendCmd(join(add(a:lines, ''), b:cmdline_nl))
 endfunction
 
 let b:cmdline_nl = "\n"

--- a/ftplugin/python_cmdline.vim
+++ b/ftplugin/python_cmdline.vim
@@ -1,7 +1,5 @@
-
 function! PythonSourceLines(lines)
-    call writefile(a:lines, g:cmdline_tmp_dir . "/lines.py")
-    call VimCmdLineSendCmd("import " . g:cmdline_tmp_dir . "/lines.py")
+  call VimCmdLineSendCmd(join(add(a:lines, ''), "\n"))
 endfunction
 
 let b:cmdline_nl = "\n"
@@ -12,4 +10,3 @@ let b:cmdline_send_empty = 1
 
 nmap <buffer><silent> <LocalLeader>s :call VimCmdLineStartApp()<CR>
 
-exe 'autocmd VimLeave * call delete(g:cmdline_tmp_dir . "/lines.py")'

--- a/ftplugin/python_cmdline.vim
+++ b/ftplugin/python_cmdline.vim
@@ -1,5 +1,5 @@
 function! PythonSourceLines(lines)
-  call VimCmdLineSendCmd(join(add(a:lines, ''), "\n"))
+    call VimCmdLineSendCmd(join(add(a:lines, ''), "\n"))
 endfunction
 
 let b:cmdline_nl = "\n"


### PR DESCRIPTION
Hi Jakson,

I was looking for something that could integrate REPL into vim. There are heaps of over-designed and hence already broken solutions. Yours one is the only one I found working. It is light and portable. I really like it. Thanks for your plugin. Just a day earlier I started working on my own implementation out of desperation. Luckily I stumbled on yours :)

I was playing with Python. I found that the temp file can be eliminated. Nothing wrong with that approach except when exception rises the implementation guts spill-out, eg:
![screenshot from 2015-12-02 01 18 18](https://cloud.githubusercontent.com/assets/177266/11501323/263ab64e-9898-11e5-9b71-ed4d9ad50134.png)

This simple fix concatenates lines and sends them directly. I have tested it both with vim 7.4 / tmux and NVIM 0.1.0-dev.

Cheers,
Rad
