### PR TITLE
Use stack ghci if available

### DIFF
--- a/ftplugin/haskell_cmdline.vim
+++ b/ftplugin/haskell_cmdline.vim
@@ -5,7 +5,11 @@ function! HaskellSourceLines(lines)
 endfunction
 
 let b:cmdline_nl = "\n"
-let b:cmdline_app = "ghci"
+if executable("stack")
+    let b:cmdline_app = "stack ghci"
+else
+    let b:cmdline_app = "ghci"
+endif
 let b:cmdline_quit_cmd = ":quit"
 let b:cmdline_source_fun = function("HaskellSourceLines")
 let b:cmdline_send_empty = 0


### PR DESCRIPTION
Fixes error where packages don't build because `ghci` searches the wrong path, while stack doesn't.