### PR TITLE
Add support for iPython

### DIFF
--- a/ftplugin/python_cmdline.vim
+++ b/ftplugin/python_cmdline.vim
@@ -4,7 +4,16 @@ if !exists("g:cmdline_job")
 endif
 
 function! PythonSourceLines(lines)
-    call VimCmdLineSendCmd(join(add(a:lines, ''), b:cmdline_nl))
+    if exists("g:cmdline_app")
+        for key in keys(g:cmdline_app)
+            if key == "python" && g:cmdline_app["python"] == "ipython"
+                call VimCmdLineSendCmd("%cpaste")
+                call VimCmdLineSendCmd(join(add(a:lines, '--'), b:cmdline_nl))
+            endif
+        endfor
+    else
+        call VimCmdLineSendCmd(join(add(a:lines, ''), b:cmdline_nl))
+    endif
 endfunction
 
 let b:cmdline_nl = "\n"
@@ -15,16 +24,5 @@ let b:cmdline_send_empty = 1
 let b:cmdline_filetype = "python"
 
 exe 'nmap <buffer><silent> ' . g:cmdline_map_start . ' :call VimCmdLineStartApp()<CR>'
-
-if exists("g:cmdline_app")
-    for key in keys(g:cmdline_app)
-        if key == "python" && g:cmdline_app["python"] == "ipython"
-            echohl WarningMsg
-            echomsg "vimcmdline does not support ipython"
-            sleep 3
-            echohl Normal
-        endif
-    endfor
-endif
 
 call VimCmdLineSetApp("python")

--- a/ftplugin/python_cmdline.vim
+++ b/ftplugin/python_cmdline.vim
@@ -3,14 +3,25 @@ if !exists("g:cmdline_job")
     runtime plugin/vimcmdline.vim
 endif
 
-function! PythonSourceLines(lines)
-    if exists("g:cmdline_app")
-        for key in keys(g:cmdline_app)
-            if key == "python" && g:cmdline_app["python"] == "ipython"
-                call VimCmdLineSendCmd("%cpaste")
-                call VimCmdLineSendCmd(join(add(a:lines, '--'), b:cmdline_nl))
+if exists("g:cmdline_app")
+    for key in keys(g:cmdline_app)
+        if key == "python" && g:cmdline_app["python"] == "ipython" 
+            if has("nvim") && g:cmdline_in_buffer == 1
+                echohl WarningMsg
+                echomsg "vimcmdline does not support ipython in builtin terminal emulator"
+                sleep 3
+                echohl Normal
+            else 
+                let b:cmdline_ipython = 1
             endif
-        endfor
+        endif
+    endfor
+endif
+
+function! PythonSourceLines(lines)
+    if exists("b:cmdline_ipython")
+        call VimCmdLineSendCmd("%cpaste")
+        call VimCmdLineSendCmd(join(add(a:lines, '--'), b:cmdline_nl))
     else
         call VimCmdLineSendCmd(join(add(a:lines, ''), b:cmdline_nl))
     endif


### PR DESCRIPTION
I added support for IPython, utilizing the `%cpaste` magic command. This works better than the regular python interpreter when sending long bits of code at once to the interpreter. For example,

```python
def foo():
    x = 2
    
    return x
```

would fail to source because of the blank line if we were sending as usual to a regular python interpreter. However, using iPython this will now work. IPython is also nice because it gives you syntax highlighting even when starting the interpreter in a new tmux pane.