### PR TITLE
Sage and Macaulay2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin sends lines from either [Vim] or [Neovim] to a command line
 interpreter (REPL application). Supported file types are Golang, Haskell, JavaScript,
-Julia, Jupyter, Lisp, Matlab, Prolog, Python, Ruby, Sage, and sh. The interpreter may
+Julia, Jupyter, Lisp, Macaulay2, Matlab, Prolog, Python, Ruby, Sage, and sh. The interpreter may
 run in a Neovim built-in terminal (Neovim buffer), an external terminal
 emulator or in a tmux pane. The main advantage of running the interpreter in a
 Neovim terminal is that the output is colorized, as in the screenshot below,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin sends lines from either [Vim] or [Neovim] to a command line
 interpreter (REPL application). Supported file types are Golang, Haskell, JavaScript,
-Julia, Jupyter, Lisp, Matlab, Prolog, Python, Ruby, and sh. The interpreter may
+Julia, Jupyter, Lisp, Matlab, Prolog, Python, Ruby, Sage, and sh. The interpreter may
 run in a Neovim built-in terminal (Neovim buffer), an external terminal
 emulator or in a tmux pane. The main advantage of running the interpreter in a
 Neovim terminal is that the output is colorized, as in the screenshot below,

--- a/ftplugin/Macaulay2_cmdline.vim
+++ b/ftplugin/Macaulay2_cmdline.vim
@@ -1,0 +1,22 @@
+" Ensure that plugin/vimcmdline.vim was sourced
+if !exists('g:cmdline_job')
+    runtime plugin/vimcmdline.vim
+endif
+
+function! Macaulay2SourceLines(lines)
+    call writefile(filter(a:lines, '!empty(v:val)'), g:cmdline_tmp_dir . '/lines.m2', 'b')
+    call VimCmdLineSendCmd('input "' . g:cmdline_tmp_dir . '/lines.m2"')
+endfunction
+
+let b:cmdline_nl = "\n"
+let b:cmdline_app = 'M2'
+let b:cmdline_quit_cmd = 'exit'
+let b:cmdline_source_fun = function('Macaulay2SourceLines')
+let b:cmdline_send_empty = 0
+let b:cmdline_filetype = 'Macaulay2'
+
+exe 'nmap <buffer><silent> ' . g:cmdline_map_start . ' :call VimCmdLineStartApp()<CR>'
+
+exe 'autocmd VimLeave * call delete(g:cmdline_tmp_dir . "/lines.m2")'
+
+call VimCmdLineSetApp('Macaulay2')

--- a/ftplugin/python_cmdline.vim
+++ b/ftplugin/python_cmdline.vim
@@ -1,3 +1,8 @@
+" skip if filetype is sage.python
+if match(&ft, '\v<sage>') != -1
+    finish
+endif
+
 " Ensure that plugin/vimcmdline.vim was sourced
 if !exists("g:cmdline_job")
     runtime plugin/vimcmdline.vim

--- a/ftplugin/sage_cmdline.vim
+++ b/ftplugin/sage_cmdline.vim
@@ -1,0 +1,21 @@
+" Ensure that plugin/vimcmdline.vim was sourced
+if !exists('g:cmdline_job')
+    runtime plugin/vimcmdline.vim
+endif
+
+function! SageSourceLines(lines)
+    call VimCmdLineSendCmd('%cpaste -q')
+    sleep 100m " Wait for IPython to read stdin
+    call VimCmdLineSendCmd(join(add(a:lines, '--'), b:cmdline_nl))
+endfunction
+
+let b:cmdline_nl = "\n"
+let b:cmdline_app = 'sage'
+let b:cmdline_quit_cmd = 'exit'
+let b:cmdline_source_fun = function('SageSourceLines')
+let b:cmdline_send_empty = 1
+let b:cmdline_filetype = 'sage'
+
+exe 'nmap <buffer><silent> ' . g:cmdline_map_start . ' :call VimCmdLineStartApp()<CR>'
+
+call VimCmdLineSetApp('sage')

--- a/plugin/vimcmdline.vim
+++ b/plugin/vimcmdline.vim
@@ -51,12 +51,15 @@ endif
 
 " Internal variables
 let g:cmdline_job = {"haskell": 0, "julia": 0, "lisp": 0, "matlab": 0, "go": 0,
-            \ "prolog": 0, "python": 0, "ruby": 0, "sh": 0, "javascript": 0}
+            \ "prolog": 0, "python": 0, "ruby": 0, "sh": 0, "javascript": 0,
+            \ "sage": 0}
 let g:cmdline_termbuf = {"haskell": "", "julia": "", "lisp": "", "matlab": "", "go": "",
-            \ "prolog": "", "python": "", "ruby": "", "sh": "", "javascript": ""}
+            \ "prolog": "", "python": "", "ruby": "", "sh": "", "javascript": "",
+            \ "sage": ""}
 let s:cmdline_app_pane = ''
 let g:cmdline_tmuxsname = {"haskell": "", "julia": "", "lisp": "", "matlab": "", "go": "",
-            \ "prolog": "", "python": "", "ruby": "", "sh": "", "javascript": ""}
+            \ "prolog": "", "python": "", "ruby": "", "sh": "", "javascript": "",
+            \ "sage": ""}
 
 " Skip empty lines
 function s:GoLineDown()

--- a/plugin/vimcmdline.vim
+++ b/plugin/vimcmdline.vim
@@ -52,14 +52,14 @@ endif
 " Internal variables
 let g:cmdline_job = {"haskell": 0, "julia": 0, "lisp": 0, "matlab": 0, "go": 0,
             \ "prolog": 0, "python": 0, "ruby": 0, "sh": 0, "javascript": 0,
-            \ "sage": 0}
+            \ "sage": 0, "Macaulay2": 0}
 let g:cmdline_termbuf = {"haskell": "", "julia": "", "lisp": "", "matlab": "", "go": "",
             \ "prolog": "", "python": "", "ruby": "", "sh": "", "javascript": "",
-            \ "sage": ""}
+            \ "sage": "", "Macaulay2": ""}
 let s:cmdline_app_pane = ''
 let g:cmdline_tmuxsname = {"haskell": "", "julia": "", "lisp": "", "matlab": "", "go": "",
             \ "prolog": "", "python": "", "ruby": "", "sh": "", "javascript": "",
-            \ "sage": ""}
+            \ "sage": "", "Macaulay2": ""}
 
 " Skip empty lines
 function s:GoLineDown()

--- a/syntax/cmdlineoutput_M2.vim
+++ b/syntax/cmdlineoutput_M2.vim
@@ -1,0 +1,10 @@
+" Vim syntax file
+" Language:    No language. Output additionals for M2
+
+runtime syntax/cmdlineoutput.vim
+
+" Input
+syn match cmdlineInput "\v^i+\d+\s+:.*%(\n\s.*)*"
+
+" Errors
+syn match cmdlineError "\v<error:.*"

--- a/syntax/cmdlineoutput_sage.vim
+++ b/syntax/cmdlineoutput_sage.vim
@@ -1,0 +1,7 @@
+" Vim syntax file
+" Language:    No language. Output additionals for sage
+
+runtime syntax/cmdlineoutput.vim
+
+" Input
+syn match cmdlineInput "\m^sage:.*"


### PR DESCRIPTION
This adds support for the mathematical softwares [Sage](https://www.sagemath.org/) and [Macaulay2](https://faculty.math.illinois.edu/Macaulay2/). I have tested the changes both in Neovim and (briefly) Vim/Tmux.

These are the file type plugins I use:
- [petRUShka/vim-sage](https://github.com/petRUShka/vim-sage),
- [coreysharris/Macaulay2.vim](https://github.com/coreysharris/Macaulay2.vim).