### PR TITLE
Clear node cache before sourcing tmp file

### DIFF
--- a/ftplugin/javascript_cmdline.vim
+++ b/ftplugin/javascript_cmdline.vim
@@ -5,6 +5,7 @@ endif
 
 function! JavaScriptSourceLines(lines)
     call writefile(a:lines, g:cmdline_tmp_dir . "/lines.js")
+    call VimCmdLineSendCmd("delete require.cache[require.resolve('" . g.cmdline_tmp_dir . "/lines.js')]")
     call VimCmdLineSendCmd("require('" . g:cmdline_tmp_dir . "/lines.js')")
 endfunction
 

--- a/ftplugin/javascript_cmdline.vim
+++ b/ftplugin/javascript_cmdline.vim
@@ -5,7 +5,7 @@ endif
 
 function! JavaScriptSourceLines(lines)
     call writefile(a:lines, g:cmdline_tmp_dir . "/lines.js")
-    call VimCmdLineSendCmd("delete require.cache[require.resolve('" . g.cmdline_tmp_dir . "/lines.js')]")
+    call VimCmdLineSendCmd("delete require.cache[require.resolve('" . g:cmdline_tmp_dir . "/lines.js')]")
     call VimCmdLineSendCmd("require('" . g:cmdline_tmp_dir . "/lines.js')")
 endfunction
 

--- a/ftplugin/javascript_cmdline.vim
+++ b/ftplugin/javascript_cmdline.vim
@@ -5,8 +5,11 @@ endif
 
 function! JavaScriptSourceLines(lines)
     call writefile(a:lines, g:cmdline_tmp_dir . "/lines.js")
-    call VimCmdLineSendCmd("delete require.cache[require.resolve('" . g:cmdline_tmp_dir . "/lines.js')]")
-    call VimCmdLineSendCmd("require('" . g:cmdline_tmp_dir . "/lines.js')")
+    " Need to delete the cache for this tmp file if it exists, otherwise the
+    " file won't be loaded again.
+    let clear_cache_command = "delete require.cache[require.resolve('" . g:cmdline_tmp_dir . "/lines.js')]; "
+    let source_file_command = "require('" . g:cmdline_tmp_dir . "/lines.js');"
+    call VimCmdLineSendCmd(clear_cache_command . source_file_command)
 endfunction
 
 let b:cmdline_nl = "\n"


### PR DESCRIPTION
Hi,

Node caches the file `/tmp/lines.js` that vimcmdline creates after sending a block of code to node, so subsequent blocks of code that are sent to node are ignored since node just checks that the `/tmp/lines.js` already exists in its cache. This proposed fix adds a command to delete `/tmp/lines.js` from the node cache before sourcing it again.