### PR TITLE
Avoid caching of Matlab run command

### DIFF
--- a/ftplugin/matlab_cmdline.vim
+++ b/ftplugin/matlab_cmdline.vim
@@ -6,7 +6,7 @@ endif
 function! OctaveSourceLines(lines)
     call writefile(a:lines, g:cmdline_tmp_dir . "/lines.m")
     if b:cmdline_app =~? "^matlab"
-        call VimCmdLineSendCmd('run("' . g:cmdline_tmp_dir . '/lines.m");')
+        call VimCmdLineSendCmd('run("' . g:cmdline_tmp_dir . '/lines.m"); clear lines.m;')
     else
         call VimCmdLineSendCmd('source("' . g:cmdline_tmp_dir . '/lines.m");')
     endif


### PR DESCRIPTION
The `run` command in Matlab caches the executed script, which causes the same lines to be executed again and again, instead of the selected ones.

This change clears the cached script, as per the Matlab documentation: https://www.mathworks.com/help/matlab/ref/run.html. Tested with Matlab R2017b.