### PR TITLE
end line should be \n

### DIFF
--- a/ftplugin/kdb_cmdline.vim
+++ b/ftplugin/kdb_cmdline.vim
@@ -9,7 +9,10 @@ function! KdbSourceLines(lines)
     call VimCmdLineSendCmd("\\l " . g:cmdline_tmp_dir . "/lines.q")
 endfunction
 
-let b:cmdline_nl = " "
+let b:cmdline_nl = "\n"
+" b:cmdline_app should not be an expression like 'rlwrap q' 
+" to do this create a script, add it to your PATH and set b:cmdlineapp
+" accordingly
 let b:cmdline_app = "q"
 let b:cmdline_quit_cmd = "\\\\"
 let b:cmdline_source_fun = function("KdbSourceLines")


### PR DESCRIPTION
The issue I had was that I wanted to use rlwrap q in b:cmdline_app. Creating a bash script and referencing the script worked.
Also nl should be \n