### PR TITLE
Fix Jupyter console support

### DIFF
--- a/ftplugin/ocaml_cmdline.vim
+++ b/ftplugin/ocaml_cmdline.vim
@@ -1,0 +1,31 @@
+" Ensure that plugin/vimcmdline.vim was sourced
+if !exists("g:cmdline_job")
+    runtime plugin/vimcmdline.vim
+endif
+
+function! OCamlSourceLines(lines)
+    for line in a:lines
+        call VimCmdLineSendCmd(substitute(line, ";;$", "", "g"))
+    endfor
+    call VimCmdLineSendCmd(";;\<CR>")
+endfunction
+
+function! OCamlSendLine()
+    let line = getline(".")
+    call VimCmdLineSendCmd(line . ";;\<CR>")
+    call VimCmdLineDown()
+endfunction
+
+let b:cmdline_nl = "\<CR>"
+let b:cmdline_app = "utop"
+let b:cmdline_quit_cmd = "#quit;;"
+let b:cmdline_send = function("OCamlSendLine")
+let b:cmdline_source_fun = function("OCamlSourceLines")
+let b:cmdline_send_empty = 1
+let b:cmdline_filetype = "ocaml"
+
+exe 'nmap <buffer><silent> ' . g:cmdline_map_start . ' :call VimCmdLineStartApp()<CR>'
+
+exe 'autocmd VimLeave * call delete(g:cmdline_tmp_dir . "/lines.ml")'
+
+call VimCmdLineSetApp("ocaml")

--- a/ftplugin/python_cmdline.vim
+++ b/ftplugin/python_cmdline.vim
@@ -11,11 +11,11 @@ endif
 if exists("g:cmdline_app")
     for key in keys(g:cmdline_app)
         if key == "python"
-	    if match(g:cmdline_app["python"], "ipython") != -1
-	        let b:cmdline_ipython = 1
-	    elseif match(g:cmdline_app["python"], "jupyter") != -1
-	        let b:cmdline_jupyter = 1
-	    endif
+            if match(g:cmdline_app["python"], "ipython") != -1
+                let b:cmdline_ipython = 1
+            elseif match(g:cmdline_app["python"], "jupyter") != -1
+                let b:cmdline_jupyter = 1
+            endif
         endif
     endfor
 endif
@@ -26,8 +26,8 @@ function! PythonSourceLines(lines)
         sleep 100m " Wait for IPython to read stdin
         call VimCmdLineSendCmd(join(add(a:lines, '--'), b:cmdline_nl))
     elseif exists("b:cmdline_jupyter")
-	" Use bracketed paste
-	call VimCmdLineSendCmd("\e[200~")
+        " Use bracketed paste
+        call VimCmdLineSendCmd("\e[200~")
         call VimCmdLineSendCmd(join(a:lines, b:cmdline_nl))
         call VimCmdLineSendCmd("\e[201~")
     else

--- a/ftplugin/python_cmdline.vim
+++ b/ftplugin/python_cmdline.vim
@@ -27,17 +27,9 @@ function! PythonSourceLines(lines)
         call VimCmdLineSendCmd(join(add(a:lines, '--'), b:cmdline_nl))
     elseif exists("b:cmdline_jupyter")
 	" Use bracketed paste
-	let a:block = join(a:lines, b:cmdline_nl)
-python << endpython
-# Allow inner blocks to be run without problem (cpaste-like)
-import textwrap, json
-block = vim.eval('a:block')
-vim.command('let a:block = %s' % json.dumps(textwrap.dedent(block)))
-endpython
 	call VimCmdLineSendCmd("\e[200~")
-        call VimCmdLineSendCmd(a:block)
+        call VimCmdLineSendCmd(join(a:lines, b:cmdline_nl))
         call VimCmdLineSendCmd("\e[201~")
-	call VimCmdLineSendCmd(b:cmdline_nl)
     else
         if a:lines[len(a:lines)-1] == ''
             call VimCmdLineSendCmd(join(a:lines, b:cmdline_nl))

--- a/ftplugin/python_cmdline.vim
+++ b/ftplugin/python_cmdline.vim
@@ -1,4 +1,4 @@
-" skip if filetype is sage.python
+" Skip if filetype is sage.python
 if match(&ft, '\v<sage>') != -1
     finish
 endif
@@ -9,24 +9,18 @@ if !exists("g:cmdline_job")
 endif
 
 if exists("g:cmdline_app")
-    for key in keys(g:cmdline_app)
-        if key == "python"
-            if match(g:cmdline_app["python"], "ipython") != -1
-                let b:cmdline_ipython = 1
-            elseif match(g:cmdline_app["python"], "jupyter") != -1
-                let b:cmdline_jupyter = 1
-            endif
+    if has_key(g:cmdline_app, "python")
+        if match(g:cmdline_app["python"], "ipython") != -1
+            let b:cmdline_ipython = 1
+        elseif match(g:cmdline_app["python"], "jupyter") != -1
+            let b:cmdline_jupyter = 1
         endif
-    endfor
+    endif
 endif
 
 function! PythonSourceLines(lines)
-    if exists("b:cmdline_ipython")
-        call VimCmdLineSendCmd("%cpaste -q")
-        sleep 100m " Wait for IPython to read stdin
-        call VimCmdLineSendCmd(join(add(a:lines, '--'), b:cmdline_nl))
-    elseif exists("b:cmdline_jupyter")
-        " Use bracketed paste
+    if exists("b:cmdline_ipython") || exists("b:cmdline_jupyter")
+        " Use bracketed paste for ipython or jupyter
         call VimCmdLineSendCmd("\e[200~")
         call VimCmdLineSendCmd(join(a:lines, b:cmdline_nl))
         call VimCmdLineSendCmd("\e[201~")


### PR DESCRIPTION
Jupyter console support seems to be added in https://github.com/jalvesaq/vimcmdline/pull/33. However, the original code causes an error in Neovim, as the function local variable `a:block` defined in `PythonSourceLines` should be `l:block` instead.

In fixing this bug, I also simplified the `PythonSourceLines` logic for Jupyter console, as simply using bracketed paste is sufficient (see https://github.com/jupyter/jupyter_console/issues/70).

Lastly, I fixed a few indentation errors in the same file.