### PR TITLE
change command for external terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Finally, if you want to run the interpreter in an external terminal emulator,
 you have to define the command to run it, as in the examples:
 
 ```vim
-let cmdline_external_term_cmd = "gnome-terminal -e '%s'"
+let cmdline_external_term_cmd = "gnome-terminal -- /bin/bash -c '%s'"
 let cmdline_external_term_cmd = "xterm -e '%s' &"
 let cmdline_external_term_cmd = 'kitty %s &'
 ```


### PR DESCRIPTION
    gnome-termnial --version

I get 

    # GNOME Terminal 3.28.2 using VTE 0.52.2 +GNUTLS -PCRE2

If I execute 

    gnome-terminal -- "echo 'hi'"

or

    gnome-terminal -- 'echo "hi"'

Then I got the error message
    There was an error creating the child process for this terminal
    Failed to execute child process “echo \'hi\'” (No such file or directory)

this works however

    gnome-terminal -- /bin/bash -c "echo 'hi'"