### PR TITLE
support for unicode when sending a selection

### DIFF
--- a/plugin/vimcmdline.vim
+++ b/plugin/vimcmdline.vim
@@ -306,15 +306,23 @@ function VimCmdLineSendLineAndStay()
     endif
 endfunction
 
+function VimCmdLineSelectionToString()
+    try
+        let a_orig = @a
+        silent! normal! gv"ay
+        return @a
+    finally
+        let @a = a_orig
+    endtry
+endfunction
+
 function VimCmdLineSendSelection()
     if line("'<") == line("'>")
-        let i = col("'<") - 1
-        let j = col("'>") - i
-        let l = getline("'<")
-        let line = strpart(l, i, j)
+        let line = VimCmdLineSelectionToString()
         call VimCmdLineSendCmd(line)
     elseif exists("b:cmdline_source_fun")
-        call b:cmdline_source_fun(getline("'<", "'>"))
+        let lines = split(VimCmdLineSelectionToString(), "\n")
+        call b:cmdline_source_fun(lines)
     endif
 endfunction
 


### PR DESCRIPTION
Sending a visual selection to the interpreter can cause problems when the last character is a multi-byte character. This is because the current implementation is based on plain bytes, not characters, so the last multi-byte character is sent only partially.

For example with a Python file containing:
```
π = 3.14
```
If I first evaluate the line as a whole, and then just select the `π` and evaluate it (twice), the result is:
```
>>> π = 3.14
>>>
>>> � File "<stdin>", line 0

    ^
SyntaxError: 'utf-8' codec can't decode byte 0xcf in position 0: invalid continuation byte
```

The desired output is:
```
>>> π = 3.14
>>> π
3.14
```

This is fixed by temporarily copying the selection to a register in order to convert it to string.

Additionally, this adds support for sending multiline selections (not necessarily line-wise), including block-wise selections.