### PR TITLE
[Magma] Add initial support for Magma Computer Algebra System

### DIFF
--- a/ftplugin/magma_cmdline.vim
+++ b/ftplugin/magma_cmdline.vim
@@ -6,7 +6,7 @@ endif
 function! MagmaSourceLines(lines)
     "call VimCmdLineSendCmd('%cpaste -q')
     "sleep 100m " Wait for IPython to read stdin
-    call VimCmdLineSendCmd(join(add(a:lines, '--'), b:cmdline_nl))
+    call VimCmdLineSendCmd(join(a:lines, b:cmdline_nl))
 endfunction
 
 let b:cmdline_nl = "\n"

--- a/ftplugin/magma_cmdline.vim
+++ b/ftplugin/magma_cmdline.vim
@@ -1,0 +1,21 @@
+" Ensure that plugin/vimcmdline.vim was sourced
+if !exists('g:cmdline_job')
+    runtime plugin/vimcmdline.vim
+endif
+
+function! MagmaSourceLines(lines)
+    "call VimCmdLineSendCmd('%cpaste -q')
+    "sleep 100m " Wait for IPython to read stdin
+    call VimCmdLineSendCmd(join(add(a:lines, '--'), b:cmdline_nl))
+endfunction
+
+let b:cmdline_nl = "\n"
+let b:cmdline_app = 'magma'
+let b:cmdline_quit_cmd = 'quit;'
+let b:cmdline_source_fun = function('MagmaSourceLines')
+let b:cmdline_send_empty = 1
+let b:cmdline_filetype = 'magma'
+
+exe 'nmap <buffer><silent> ' . g:cmdline_map_start . ' :call VimCmdLineStartApp()<CR>'
+
+call VimCmdLineSetApp('magma')


### PR DESCRIPTION
Magma Computer Algebra system is a proprioritary computer algebra system designed to solve problems in algebra, number theory, geometry and combinatorics. Which is quite famous for the area. Webpage: https://magma.maths.usyd.edu.au/

There is a vim-magma plugin with support of *.mag files: https://github.com/petRUShka/vim-magma.

Code of `ftplugin/magma_cmdline.vim` is based on `ftplugin/sage_cmdline.vim`.