### PR TITLE
Add support for Zellij

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ If the file type is `quarto`, `vimcmdline` will try to infer what interpreter
 should be started.
 
 The interpreter runs in Neovim's built-in terminal.
-If Tmux is installed, the interpreter can also run in
-an external terminal emulator or in a tmux pane. The main advantage
-of running the interpreter in a Neovim terminal is that the output is
+If Tmux or Zellij is installed, the interpreter can also run in
+an external terminal emulator (tmux-only) or in a tmux/zellij pane. The main
+advantage of running the interpreter in a Neovim terminal is that the output is
 colorized, as in the screenshot below, where we have different colors for
 general output, positive and negative numbers, and the prompt line:
 
@@ -20,7 +20,7 @@ general output, positive and negative numbers, and the prompt line:
 
 If running in either a Neovim built-in terminal or an external terminal, the
 plugin runs one instance of the REPL application for each file type. If
-running in a tmux pane, it runs one REPL application for Vim instance.
+running in a tmux or zellij pane, it runs one REPL application for Vim instance.
 
 Support for running the interpreter in Vim's built-in terminal was not
 implemented.
@@ -32,8 +32,9 @@ in its terminal.
 
 Use a plugin manager to install vimcmdline.
 
-You have to install Tmux if you either want to run the interpreter in an
-external terminal emulator or are using Vim.
+You need to install either Tmux or Zellij if you want to run the interpreter in
+a split pane. Note that external terminal emulator support requires Tmux
+specifically. If you are using Vim (not Neovim), you must have Tmux installed.
 
 
 ## Usage and options
@@ -56,7 +57,8 @@ for further instructions.
   3. Edit the new script and change the values of its variables as necessary.
 
   4. Test your new file-type script by running your application in either Vim
-     or Neovim and using either the built-in terminal or a Tmux split pane.
+     or Neovim and using either the built-in terminal or a Tmux/Zellij split
+     pane.
 
   5. Look at the Vim scripts in the `syntax` directory and make a copy of the
      script supporting the language whose output is closer to the output of

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -167,15 +167,15 @@ function cmdline#Start_Zellij(app)
         return
     endif
 
-    let zcmd = "zellij run --floating "
+    let zcmd = "zellij action new-pane -d "
     if g:cmdline_vsplit
-        if g:cmdline_term_width == -1
-            let zcmd .= "--width-percent 50 "
-        else
-            let zcmd .= "--width " . g:cmdline_term_width . " "
+        let zcmd .= "right "
+        if g:cmdline_term_width != -1
+            let zcmd .= "--size " . g:cmdline_term_width . " "
         endif
     else
-        let zcmd .= "--height " . g:cmdline_term_height . " "
+        let zcmd .= "down "
+        let zcmd .= "--size " . g:cmdline_term_height . " "
     endif
     let zcmd .= " -- " . a:app
 
@@ -356,7 +356,7 @@ function cmdline#SendCmd(...)
                 unlet g:cmdline_tmuxsname[b:cmdline_filetype]
             endif
         elseif g:cmdline_use_zellij && g:cmdline_zellij_pane != ''
-            let zcmd = "zellij write-chars '" . str . "\n' --pane-id " . g:cmdline_zellij_pane
+            let zcmd = "zellij action write-chars '" . str . "\n' --pane-id " . g:cmdline_zellij_pane
             call system(zcmd)
             if v:shell_error
                 echohl WarningMsg

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -199,6 +199,16 @@ function cmdline#Start_Zellij(app)
         return
     endif
 
+    " Refocus nvim after creating the new pane
+    let focus_nvim = "zellij action focus-previous-pane"
+    call system(focus_nvim)
+    if v:shell_error
+        echohl ErrorMsg
+        echomsg "ERROR: Focus command failed with error: " . v:shell_error
+        echohl Normal
+        return
+    endif
+
     " Store that we created a pane
     let g:cmdline_zellij_pane = 1
 endfunction

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -363,8 +363,13 @@ function cmdline#SendCmd(...)
                 unlet g:cmdline_tmuxsname[b:cmdline_filetype]
             endif
         elseif g:cmdline_use_zellij && g:cmdline_zellij_pane != ''
-            let zcmd = "zellij action write-chars '" . str . "\n' --pane-id " . g:cmdline_zellij_pane
+            " For Zellij, we need to focus the pane first
+            let focus_cmd = "zellij action focus-next-pane"
+            call system(focus_cmd)
+
+            " Then write the command
             call system(zcmd)
+            let zcmd = "zellij action write-chars '" . str . "\n'"
             if v:shell_error
                 echohl WarningMsg
                 echomsg 'Failed to send command. Is "' . b:cmdline_app . '" running?'

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -363,13 +363,24 @@ function cmdline#SendCmd(...)
                 unlet g:cmdline_tmuxsname[b:cmdline_filetype]
             endif
         elseif g:cmdline_use_zellij && g:cmdline_zellij_pane != ''
-            " For Zellij, we need to focus the pane first
+            " For Zellij, we need to focus the next pane and write the command
             let focus_cmd = "zellij action focus-next-pane"
             call system(focus_cmd)
 
-            " Then write the command
-            let zcmd = "zellij action write-chars '" . str . "\n'"
-            call system(zcmd)
+            sleep 50m  " Give Zellij a moment to switch focus
+
+            " Write the command character by character to ensure proper input
+            let write_cmd = "zellij action write-chars '" . str . "'"
+            call system(write_cmd)
+
+            " Send the enter key separately
+            let enter_cmd = "zellij action write-chars '\n'"
+            call system(enter_cmd)
+
+            " Return focus to vim pane
+            let return_focus_cmd = "zellij action focus-previous-pane"
+            call system(return_focus_cmd)
+
             if v:shell_error
                 echohl WarningMsg
                 echomsg 'Failed to send command. Is "' . b:cmdline_app . '" running?'

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -368,8 +368,8 @@ function cmdline#SendCmd(...)
             call system(focus_cmd)
 
             " Then write the command
-            call system(zcmd)
             let zcmd = "zellij action write-chars '" . str . "\n'"
+            call system(zcmd)
             if v:shell_error
                 echohl WarningMsg
                 echomsg 'Failed to send command. Is "' . b:cmdline_app . '" running?'

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -182,7 +182,9 @@ function cmdline#Start_Zellij(app)
     " Create new pane and get its ID
     let pane_info = system(zcmd)
     if v:shell_error
-        exe 'echoerr ' . pane_info
+        echohl ErrorMsg
+        echomsg "Failed to create Zellij pane: " . pane_info
+        echohl Normal
         return
     endif
 

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -202,11 +202,25 @@ function cmdline#Start_Zellij(app)
 
     " After creating the pane, resize it
     if g:cmdline_vsplit && g:cmdline_term_width != -1
-        let resize_cmd = "zellij action resize left " . (winwidth(0) - g:cmdline_term_width)
-        call system(resize_cmd)
-    elseif !g:cmdline_vsplit
-        let resize_cmd = "zellij action resize up " . (winheight(0) - g:cmdline_term_height)
-        call system(resize_cmd)
+        " Calculate how many times we need to resize to achieve desired width
+        let current_width = winwidth(0)
+        let target_width = g:cmdline_term_width
+        let resize_amount = (current_width - target_width) / 2
+
+        if resize_amount > 0
+            let resize_cmd = "zellij action resize decrease-horizontal " . resize_amount
+            call system(resize_cmd)
+        endif
+    elseif !g:cmdline_vsplit && g:cmdline_term_height != -1
+        " Calculate how many times we need to resize to achieve desired height
+        let current_height = winheight(0)
+        let target_height = g:cmdline_term_height
+        let resize_amount = (current_height - target_height) / 2
+
+        if resize_amount > 0
+            let resize_cmd = "zellij action resize decrease-vertical " . resize_amount
+            call system(resize_cmd)
+        endif
     endif
 
     " Store that we created a pane

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -196,6 +196,12 @@ function cmdline#Start_Zellij(app)
     " Store the pane ID for later use
     let g:cmdline_zellij_pane = pane_info
     let g:cmdline_zellij_session[b:cmdline_filetype] = localtime()
+
+
+    echomsg "DEBUG: Attempting to send command via Zellij"
+    echomsg "DEBUG: ZELLIJ env var = " . $ZELLIJ
+    echomsg "DEBUG: Zellij pane = " . g:cmdline_zellij_pane
+    echomsg "DEBUG: Zellij session = " . g:cmdline_zellij_session
 endfunction
 
 " Run the interpreter in a Tmux panel

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -46,7 +46,6 @@ function cmdline#Init()
     let s:cmdline_app_pane = ''
 
     " Zellij specific variables and configuration option
-    let g:cmdline_zellij_session = {}
     let g:cmdline_zellij_pane = 0
     let g:cmdline_use_zellij = get(g:, 'cmdline_use_zellij', 0)
 
@@ -202,7 +201,6 @@ function cmdline#Start_Zellij(app)
 
     " Store that we created a pane
     let g:cmdline_zellij_pane = 1
-    let g:cmdline_zellij_session[b:cmdline_filetype] = localtime()
 endfunction
 
 " Run the interpreter in a Tmux panel
@@ -579,7 +577,6 @@ function cmdline#Quit(ftype)
             let g:cmdline_termbuf[a:ftype] = ""
         endif
         let g:cmdline_tmuxsname[a:ftype] = ""
-        let g:cmdline_zellij_session[a:ftype] = ""
         let g:cmdline_zellij_pane = 0
         let s:cmdline_app_pane = ''
     else

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -167,15 +167,11 @@ function cmdline#Start_Zellij(app)
         return
     endif
 
-    let zcmd = "zellij action new-pane -d "
+    let zcmd = "zellij action new-pane "
     if g:cmdline_vsplit
-        let zcmd .= "right "
-        if g:cmdline_term_width != -1
-            let zcmd .= "--size " . g:cmdline_term_width . " "
-        endif
+        let zcmd .= "-d right "
     else
-        let zcmd .= "down "
-        let zcmd .= "--size " . g:cmdline_term_height . " "
+        let zcmd .= "-d down "
     endif
     let zcmd .= " -- " . a:app
 
@@ -186,6 +182,15 @@ function cmdline#Start_Zellij(app)
         echomsg "Failed to create Zellij pane: " . pane_info
         echohl Normal
         return
+    endif
+
+    " After creating the pane, resize it
+    if g:cmdline_vsplit && g:cmdline_term_width != -1
+        let resize_cmd = "zellij action resize left " . (winwidth(0) - g:cmdline_term_width)
+        call system(resize_cmd)
+    elseif !g:cmdline_vsplit
+        let resize_cmd = "zellij action resize up " . (winheight(0) - g:cmdline_term_height)
+        call system(resize_cmd)
     endif
 
     " Store the pane ID for later use

--- a/autoload/cmdline.vim
+++ b/autoload/cmdline.vim
@@ -200,29 +200,6 @@ function cmdline#Start_Zellij(app)
         return
     endif
 
-    " After creating the pane, resize it
-    if g:cmdline_vsplit && g:cmdline_term_width != -1
-        " Calculate how many times we need to resize to achieve desired width
-        let current_width = winwidth(0)
-        let target_width = g:cmdline_term_width
-        let resize_amount = (current_width - target_width) / 2
-
-        if resize_amount > 0
-            let resize_cmd = "zellij action resize decrease-horizontal " . resize_amount
-            call system(resize_cmd)
-        endif
-    elseif !g:cmdline_vsplit && g:cmdline_term_height != -1
-        " Calculate how many times we need to resize to achieve desired height
-        let current_height = winheight(0)
-        let target_height = g:cmdline_term_height
-        let resize_amount = (current_height - target_height) / 2
-
-        if resize_amount > 0
-            let resize_cmd = "zellij action resize decrease-vertical " . resize_amount
-            call system(resize_cmd)
-        endif
-    endif
-
     " Store that we created a pane
     let g:cmdline_zellij_pane = 1
     let g:cmdline_zellij_session[b:cmdline_filetype] = localtime()

--- a/doc/vimcmdline.txt
+++ b/doc/vimcmdline.txt
@@ -28,11 +28,11 @@ Author: Jakson A. Aquino <jalvesaq@gmail.com>
 
 This plugin sends lines from either Vim or Neovim to a command line
 interpreter (REPL application). The interpreter runs in either Neovim or Vim
-built-in terminal. If Tmux is installed, the interpreter can also run in an
-external terminal emulator or in a tmux pane. If running in either a Neovim
-built-in terminal or an external terminal, the plugin runs one instance of the
-REPL application for each file type. If running in a tmux pane, it runs one
-REPL application for Vim instance.
+built-in terminal. If Tmux or Zellij is installed, the interpreter can also run
+in an external terminal emulator (tmux-only feature) or in a tmux/zellij pane.
+If running in either a Neovim built-in terminal or an external terminal, the
+plugin runs one instance of the REPL application for each file type. If running
+in a tmux or zellij pane, it runs one REPL application for Vim instance.
 
 
 ==============================================================================
@@ -188,10 +188,19 @@ the interpreter, put in your |vimrc|:
 <
 							   *cmdline_in_buffer*
 If you are running Neovim, the interpreter will be started in its built-in
-terminal. If you prefer to start it in a Tmux split pane, put in your |vimrc|:
+terminal. If you prefer to start it in a Tmux or Zellij split pane, put in your
+|vimrc|:
 >
  let cmdline_in_buffer = 0
 <
+							   *cmdline_use_zellij*
+By default, when not using the built-in terminal, vimcmdline will use Tmux for
+splitting panes. If you prefer to use Zellij instead, put in your |vimrc|:
+>
+ let cmdline_use_zellij = 1
+<
+Note: This option requires that you are already running inside a Zellij session
+($ZELLIJ environment variable must be set).
 							 *cmdline_term_height*
 The terminal height will be 15 lines, but you can change it in your |vimrc|:
 >


### PR DESCRIPTION
This PR addresses https://github.com/jalvesaq/vimcmdline/issues/108

It adds support for Zellij, which can be activated via the config:

```
    config = function(_)
      vim.g.cmdline_in_buffer = 0
      vim.g.cmdline_use_zellij = 1
    end
```

It's not as advanced as the tmux implementation, because Zellij do not have pane ids yet.
Fully replicating what you can do with tmux would require a Zellij plugin.
Let me know what you think about it :+1: 