### PR TITLE
use system call via a list to not invoke a shell with each send

### DIFF
--- a/lua/hlterm/init.lua
+++ b/lua/hlterm/init.lua
@@ -561,10 +561,8 @@ local function send_cmd_exterm(ft, txt)
         return
     end
 
-    local scmd = "tmux -L HlTerm set-buffer '" .. txt .. "\13'"
-    vim.fn.system(scmd)
-    scmd = "tmux -L HlTerm paste-buffer -t hlterm" .. ft .. ".0"
-    vim.fn.system(scmd)
+    vim.fn.system({ "tmux", "-L", "HlTerm", "set-buffer", txt .. "\r" })
+    vim.fn.system({ "tmux", "-L", "HlTerm", "paste-buffer", "-t", "hlterm" .. ft .. ".0" })
     if vim.v.shell_error ~= 0 then
         cwarn('Failed to send command. Is "' .. ftopt[ft].app .. '" running?')
     end
@@ -576,10 +574,8 @@ end
 local function send_cmd_tmux(ft, txt)
     vim.notify("send_cmd_tmux [" .. app_pane[ft] .. "]: " .. ft .. " " .. txt)
 
-    local scmd = "tmux set-buffer '" .. txt .. "\13'"
-    vim.fn.system(scmd)
-    scmd = "tmux paste-buffer -t " .. app_pane[ft]
-    vim.fn.system(scmd)
+    vim.fn.system({ "tmux", "set-buffer", txt .. "\r" })
+    vim.fn.system({ "tmux", "paste-buffer", "-t", vim.trim(app_pane[ft]) })
     if vim.v.shell_error ~= 0 then
         cwarn('Failed to send command. Is "' .. ftopt[ft].app .. '" running?')
         app_pane[ft] = nil


### PR DESCRIPTION
This is a patch to address https://github.com/jalvesaq/hlterm/issues/111:

The current implementation of _hlterm_ spawns a shell for each send to _tmux_. On the server I'm working, my shell is on a shared network drive and takes some time to start up, which delays every send to the REPL. This can be tested by starting Neovim with `SHELL=/bin/sh nvim`, after which it no longer suffers from this delay.

This patch [avoids invoking the shell](https://neovim.io/doc/user/lua/#vim.system()) by supplying the `vim.fn.system` command with a list as function argument. In my testing, this completely abolishes the delay without changing the `$SHELL`.